### PR TITLE
removes subjects in favor of always returning Observable<Void>

### DIFF
--- a/src/main/java/com/netflix/prana/http/Context.java
+++ b/src/main/java/com/netflix/prana/http/Context.java
@@ -17,6 +17,7 @@
 package com.netflix.prana.http;
 
 import io.netty.handler.codec.http.HttpResponseStatus;
+import rx.Observable;
 
 import java.util.List;
 
@@ -30,14 +31,14 @@ public interface Context {
      *
      * @param object response object
      */
-    void send(Object object);
+    Observable<Void> send(Object object);
 
     /**
      * Sends a simple text message back through the response stream
      *
      * @param message the message to deliver
      */
-    void sendSimple(String message);
+    Observable<Void> sendSimple(String message);
 
     /**
      * Serializes a simple error message back to the response using the supplied status code
@@ -45,7 +46,7 @@ public interface Context {
      * @param status the status code for the response
      * @param message the message to send back to the caller
      */
-    void sendError(HttpResponseStatus status, String message);
+    Observable<Void> sendError(HttpResponseStatus status, String message);
 
     /**
      * Retrieves the value of the specified header

--- a/src/main/java/com/netflix/prana/http/api/AbstractRequestHandler.java
+++ b/src/main/java/com/netflix/prana/http/api/AbstractRequestHandler.java
@@ -33,12 +33,11 @@ public abstract class AbstractRequestHandler implements RequestHandler<ByteBuf, 
         this.objectMapper = objectMapper;
     }
 
-    abstract void handle(Context context);
+    abstract Observable<Void> handle(Context context);
 
     @Override
     public Observable<Void> handle(HttpServerRequest<ByteBuf> request, final HttpServerResponse<ByteBuf> response) {
         DefaultContext context = new DefaultContext(request, response, objectMapper);
-        handle(context);
-        return context.getResponseSubject();
+        return handle(context);
     }
 }

--- a/src/main/java/com/netflix/prana/http/api/DynamicPropertiesHandler.java
+++ b/src/main/java/com/netflix/prana/http/api/DynamicPropertiesHandler.java
@@ -18,6 +18,7 @@ package com.netflix.prana.http.api;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.config.DynamicProperty;
 import com.netflix.prana.http.Context;
+import rx.Observable;
 
 import javax.inject.Inject;
 import java.util.HashMap;
@@ -37,13 +38,13 @@ public class DynamicPropertiesHandler extends AbstractRequestHandler {
     }
 
     @Override
-    void handle(Context context) {
+    Observable<Void> handle(Context context) {
         Map<String, String> properties = new HashMap<>();
         List<String> ids = context.getQueryParams(ID_QUERY_PARAMETER);
         for (String id : ids) {
             String property = DynamicProperty.getInstance(id).getString(null);
             properties.put(id, property);
         }
-        context.send(properties);
+        return context.send(properties);
     }
 }

--- a/src/main/java/com/netflix/prana/http/api/HealthCheckHandler.java
+++ b/src/main/java/com/netflix/prana/http/api/HealthCheckHandler.java
@@ -52,14 +52,14 @@ public class HealthCheckHandler extends AbstractRequestHandler {
     }
 
     @Override
-    void handle(final Context context) {
+    Observable<Void> handle(final Context context) {
         String externalHealthCheckURL = DynamicProperty.getInstance("prana.host.healthcheck.url")
                 .getString(DEFAULT_HEALTHCHECK_ENDPOINT);
         context.setHeader("Content-type", DEFAULT_CONTENT_TYPE);
         if (Strings.isNullOrEmpty(externalHealthCheckURL)) {
-            context.sendSimple(DEFAULT_OK_HEALTH);
+            return context.sendSimple(DEFAULT_OK_HEALTH);
         } else {
-            getResponse(externalHealthCheckURL).flatMap(new Func1<HttpClientResponse<ByteBuf>, Observable<Void>>() {
+            return getResponse(externalHealthCheckURL).flatMap(new Func1<HttpClientResponse<ByteBuf>, Observable<Void>>() {
                 @Override
                 public Observable<Void> call(HttpClientResponse<ByteBuf> response) {
                     if (response.getStatus().code() == HttpResponseStatus.OK.code()) {
@@ -75,7 +75,7 @@ public class HealthCheckHandler extends AbstractRequestHandler {
                     context.sendError(HttpResponseStatus.SERVICE_UNAVAILABLE, DEFAULT_FAIL_HEALTH);
                     return DEFAULT_NOOP_RESPONSE;
                 }
-            }).subscribe();
+            });
         }
     }
 

--- a/src/main/java/com/netflix/prana/http/api/HostsHandler.java
+++ b/src/main/java/com/netflix/prana/http/api/HostsHandler.java
@@ -22,6 +22,7 @@ import com.netflix.appinfo.InstanceInfo;
 import com.netflix.prana.http.Context;
 import com.netflix.prana.service.HostService;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import rx.Observable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -42,11 +43,11 @@ public class HostsHandler extends AbstractRequestHandler {
     }
 
     @Override
-    public void handle(Context context) {
+    Observable<Void> handle(Context context) {
         String appName = context.getQueryParam("appName");
         String vip = context.getQueryParam("vip");
         if (Strings.isNullOrEmpty(appName)) {
-            context.sendError(HttpResponseStatus.BAD_REQUEST, "appName has to be specified");
+            return context.sendError(HttpResponseStatus.BAD_REQUEST, "appName has to be specified");
         } else {
             List<InstanceInfo> instances = hostService.getHosts(appName);
             List<String> hosts = new ArrayList<>();
@@ -56,7 +57,7 @@ public class HostsHandler extends AbstractRequestHandler {
                 }
                 hosts.add(instanceInfo.getHostName());
             }
-            context.send(hosts);
+            return context.send(hosts);
         }
     }
 }

--- a/src/main/java/com/netflix/prana/http/api/PingHandler.java
+++ b/src/main/java/com/netflix/prana/http/api/PingHandler.java
@@ -17,6 +17,7 @@ package com.netflix.prana.http.api;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.prana.http.Context;
+import rx.Observable;
 
 import javax.inject.Inject;
 
@@ -32,8 +33,8 @@ public class PingHandler extends AbstractRequestHandler {
     }
 
     @Override
-    void handle(Context context) {
+    Observable<Void> handle(Context context) {
         context.setHeader(CACHE_CONTROL_HEADER, CACHE_CONTROL_HEADER_VAL);
-        context.sendSimple(DEFAULT_PONG_RESPONSE);
+        return context.sendSimple(DEFAULT_PONG_RESPONSE);
     }
 }

--- a/src/main/java/com/netflix/prana/http/api/StatusHandler.java
+++ b/src/main/java/com/netflix/prana/http/api/StatusHandler.java
@@ -19,6 +19,7 @@ package com.netflix.prana.http.api;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.appinfo.ApplicationInfoManager;
 import com.netflix.prana.http.Context;
+import rx.Observable;
 
 import javax.inject.Inject;
 import java.util.HashMap;
@@ -38,10 +39,10 @@ public class StatusHandler extends AbstractRequestHandler {
     }
 
     @Override
-    void handle(Context context) {
+    Observable<Void> handle(Context context) {
         Map<String, String> status = new HashMap<String, String>() {{
             put("status", applicationInfoManager.getInfo().getStatus().name());
         }};
-        context.send(status);
+        return context.send(status);
     }
 }


### PR DESCRIPTION
@diptanu per our discussion, this PR removes the subject from the `Context` and forces handler implementations to return `Observable<Void>`
