### PR TITLE
Add Nike prana health check plugin impl.

### DIFF
--- a/src/main/java/com/netflix/prana/service/healthcheck/DefaultHealthCheck.java
+++ b/src/main/java/com/netflix/prana/service/healthcheck/DefaultHealthCheck.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.prana.service.healthcheck;
+
+import com.google.common.base.Strings;
+import com.netflix.config.DynamicProperty;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelOption;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.reactivex.netty.RxNetty;
+import io.reactivex.netty.pipeline.PipelineConfigurators;
+import io.reactivex.netty.protocol.http.client.HttpClient;
+import io.reactivex.netty.protocol.http.client.HttpClientRequest;
+import io.reactivex.netty.protocol.http.client.HttpClientResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import rx.Observable;
+import rx.exceptions.OnErrorThrowable;
+import rx.functions.Func1;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+/**
+ * A default implementation of a HealthCheck that uses an HTTP GET request to determine the health status of a third
+ * party application.
+ */
+public class DefaultHealthCheck implements HealthCheck {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultHealthCheck.class);
+    public static final int DEFAULT_APPLICATION_PORT = 7101;
+    public static final int DEFAULT_CONNECTION_TIMEOUT = 2000;
+    public static final String DEFAULT_HEALTHCHECK_ENDPOINT = "http://localhost:7001/healthcheck";
+
+    /**
+     * Determine the health of the associated app by making an HTTP GET request to a specified URL
+     * @return A tuple containing the health status of the app and a message
+     */
+    @Override
+    public Observable<HealthStatus> getHealthStatus() {
+        String externalHealthCheckURL = DynamicProperty.getInstance("prana.host.healthcheck.url")
+                .getString(DEFAULT_HEALTHCHECK_ENDPOINT);
+        if (Strings.isNullOrEmpty(externalHealthCheckURL)) {
+            // No URL to check
+            LOGGER.info("No external health check URL was provided while using the default HealthCheck implementation");
+            return Observable.just(HealthStatus.HEALTHY);
+        } else {
+            return getResponse(externalHealthCheckURL).flatMap(new Func1<HttpClientResponse<ByteBuf>, Observable<HealthStatus>>() {
+                @Override
+                public Observable<HealthStatus> call(HttpClientResponse<ByteBuf> response) {
+                    if (response.getStatus().code() == HttpResponseStatus.OK.code()) {
+                        return Observable.just(HealthStatus.HEALTHY);
+                    } else {
+                        return Observable.just(HealthStatus.UNHEALTHY);
+                    }
+                }
+            }).onErrorFlatMap(new Func1<OnErrorThrowable, Observable<HealthStatus>>() {
+                @Override
+                public Observable<HealthStatus> call(OnErrorThrowable onErrorThrowable) {
+                    LOGGER.error("Error getting Http Health Check", onErrorThrowable);
+                    return Observable.just(HealthStatus.ERROR);
+                }
+            });
+        }
+    }
+
+    private Observable<HttpClientResponse<ByteBuf>> getResponse(String externalHealthCheckURL) {
+        String host = "localhost";
+        int port = DEFAULT_APPLICATION_PORT;
+        String path = "/healthcheck";
+        try {
+            URL url = new URL(externalHealthCheckURL);
+            host = url.getHost();
+            port = url.getPort();
+            path = url.getPath();
+        } catch (MalformedURLException e) {
+            //continue
+        }
+        Integer timeout = DynamicProperty.getInstance("prana.host.healthcheck.timeout").getInteger(DEFAULT_CONNECTION_TIMEOUT);
+        HttpClient<ByteBuf, ByteBuf> httpClient = RxNetty.<ByteBuf, ByteBuf>newHttpClientBuilder(host, port)
+                .pipelineConfigurator(PipelineConfigurators.<ByteBuf, ByteBuf>httpClientConfigurator())
+                .channelOption(ChannelOption.CONNECT_TIMEOUT_MILLIS, timeout)
+                .build();
+        return httpClient.submit(HttpClientRequest.createGet(path));
+
+    }
+}

--- a/src/main/java/com/netflix/prana/service/healthcheck/HealthCheck.java
+++ b/src/main/java/com/netflix/prana/service/healthcheck/HealthCheck.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2015 Nike, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.prana.service.healthcheck;
+
+import rx.Observable;
+
+/**
+ * HealthCheckService looks for implementations of this interface
+ */
+public interface HealthCheck {
+    Observable<HealthStatus> getHealthStatus();
+}

--- a/src/main/java/com/netflix/prana/service/healthcheck/HealthCheckService.java
+++ b/src/main/java/com/netflix/prana/service/healthcheck/HealthCheckService.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2015 Nike, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.prana.service.healthcheck;
+
+import com.netflix.config.ConfigurationManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import rx.Observable;
+
+import java.io.File;
+import java.io.FilenameFilter;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ServiceConfigurationError;
+import java.util.ServiceLoader;
+
+/**
+ * A service to retrieve the {@link HealthCheck} service provider implementations.
+ */
+public final class HealthCheckService {
+    private static final Logger LOGGER = LoggerFactory.getLogger(HealthCheckService.class);
+    private static final String HC_PLUGIN_DIR_PROPERTY = "healthcheck.plugins.directory";
+    private static final String DEFAULT_HC_PLUGIN_DIR = "/var/prana/plugins/healthcheck";
+
+    private static final HealthCheckService INSTANCE = new HealthCheckService();
+
+    private ServiceLoader<HealthCheck> loader;
+
+    private volatile HealthCheck healthCheck = null;
+
+    private HealthCheckService() {
+        final String pluginDir = ConfigurationManager.getConfigInstance().getString(HC_PLUGIN_DIR_PROPERTY, DEFAULT_HC_PLUGIN_DIR);
+        LOGGER.info("Loading healthcheck plugins from " + pluginDir);
+
+        final File dir = new File(pluginDir);
+
+        if (!dir.exists()) {
+            LOGGER.warn("The healthcheck plugin directory (" + pluginDir + ") doesn't exist.");
+            return;
+        }
+        if (!dir.isDirectory()) {
+            LOGGER.warn("The healthcheck plugin directory (" + pluginDir + ") isn't a directory.");
+            return;
+        }
+
+        File[] jarList = dir.listFiles(new FilenameFilter() {
+            @Override
+            public boolean accept(File dir, String name) {
+                return name.endsWith(".jar");
+            }
+        });
+
+        // listFiles will return null if there was an IO error
+        if (jarList == null) {
+            LOGGER.error("There was an error reading from the specified healthcheck plugin directory (" + pluginDir + ").");
+            jarList = new File[0];
+        }
+
+        final URL[] urls = new URL[jarList.length];
+
+        try {
+            for (int i = 0; i < jarList.length; i++) {
+                urls[i] = jarList[i].toURI().toURL();
+            }
+        } catch (MalformedURLException mue) {
+            LOGGER.error("Error parsing plugin directory.", mue);
+            return;
+        }
+
+        final URLClassLoader classLoader = new URLClassLoader(urls);
+        loader = ServiceLoader.load(HealthCheck.class, classLoader);
+    }
+
+    public static HealthCheckService getInstance() {
+        return INSTANCE;
+    }
+
+    /**
+     * Gets the current health status of the associated application. This method will also determine which HealthCheck
+     * implementation to use if one hasn't already been set. It will first attempt to use the ServiceLoader to find
+     * HealthCheck implementations. If it doesn't find any, then it will revert to the default HTTP-based health check.
+     * If it finds multiple implementations, then it will throw an IllegalStateException, as we have no way to
+     * determine which implementation should be used.
+     * @return An observable wrapping the HealthStatus of the associated application.
+     */
+    public Observable<HealthStatus> getHealthStatus() {
+        // If we don't have an implementation of the healthcheck service, then go look for one
+        if (healthCheck == null) {
+            synchronized (HealthCheck.class) {
+                if (healthCheck == null) {
+                    try {
+                        // If the service loader couldn't be setup, then revert to the default
+                        if (loader == null) {
+                            LOGGER.info("Using the default HealthCheck implementation.");
+                            healthCheck = new DefaultHealthCheck();
+                        } else {
+                            for (HealthCheck hc : loader) {
+                                LOGGER.info("Found HealthCheck service implementation: " + hc.toString());
+                                if (healthCheck == null) {
+                                    healthCheck = hc;
+                                } else {
+                                    // Multiple implementations constitutes illegal state
+                                    throw new IllegalStateException("Found multiple implementations of the HealthCheck service. Please ensure that only one implementation is contained in your healthcheck plugin directory.");
+                                }
+                            }
+                            if (healthCheck == null) {
+                                // Didn't find any health check implementations, revert to default
+                                LOGGER.info("Didn't find implementations of the HealthCheck service in your healthcheck plugin directory. Reverting to default.");
+                                healthCheck = new DefaultHealthCheck();
+                            }
+                        }
+                    } catch (ServiceConfigurationError serviceError) {
+                        LOGGER.error("Error using HealthCheck service.", serviceError);
+                        throw new IllegalStateException("There was an error configuring the ServiceLoader.", serviceError);
+                    }
+                }
+            }
+        }
+        return healthCheck.getHealthStatus();
+    }
+}

--- a/src/main/java/com/netflix/prana/service/healthcheck/HealthStatus.java
+++ b/src/main/java/com/netflix/prana/service/healthcheck/HealthStatus.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2015 Nike, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.prana.service.healthcheck;
+
+/**
+ * A unified way for implementations of HealthCheck to return a standardized status.
+ */
+public enum HealthStatus {
+    HEALTHY,
+    UNHEALTHY,
+    ERROR,
+    UNKNOWN
+}


### PR DESCRIPTION
We needed a way to run Prana alongside applications other than web apps, and as such we needed a way to let Prana determine the health of those applications. To do this, we basically replaced the existing HealthCheck implementation with a plugin-based system that includes a default implementation to ensure it is still backwards compatible.

To do this, we pulled out most of the logic from the HealthCheckHandler and now the handler calls into a HealthCheckService. That service uses a ServiceLoader to look through a specific directory (configured via an archaius property) for .jar files that contain an implementation of a new HealthCheck interface. It then bootstraps those implementations and attempts to use them to determine the health of whatever app Prana is paired with. If there are no external implementations found, then the service defaults to using a DefaultHealthCheck which is the same one that Prana used before. This logic is only run the first time the HealthCheck endpoint is hit, and because of the default implementation, it should be completely backwards compatible.

Within Nike we've been using this implementation, and thought it might be a good candidate for Prana. If this is something you guys are interested in, I can also provide you with some documentation that explains pretty clearly how to make a new healthcheck implementation, build it into a jar, and add it to the plugin directory.